### PR TITLE
chore(itemtree): use iconpath to enable tooltip and update style

### DIFF
--- a/addon/chrome/content/preferences.xhtml
+++ b/addon/chrome/content/preferences.xhtml
@@ -10,11 +10,13 @@
 			id="zotero-prefpane-__addonRef__-annotationscount-show-icon"
 			preference="extensions.zotero.__addonRef__.annotationscount-show-icon"
 			data-l10n-id="pref-annotationscount-show-icon"
+			native="true"
 		/>
 		<checkbox
 			id="zotero-prefpane-__addonRef__-annotationscount-hide-zeros"
 			preference="extensions.zotero.__addonRef__.annotationscount-hide-zeros"
 			data-l10n-id="pref-annotationscount-hide-zeros"
+			native="true"
 		/>
 	</groupbox>
 </vbox>

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -42,12 +42,13 @@ export default class ZoteroAnnotationsCount {
 	addAnnotationsCountColumn() {
 		this.annotationsCountColumnId = Zotero.ItemTreeManager.registerColumn({
 			dataKey: `${config.addonID.replaceAll("-", "_").replaceAll("@", "_at_").replaceAll(".", "_")}_${ANNOTATIONS_COUNT_COLUMN_ID}`,
-			// If we just want to show the icon, overwrite the label with htmlLabel (#1)
-			htmlLabel: getPref(ANNOTATIONS_COUNT_COLUMN_FORMAT_SHOW_ICON_PREF)
-				? `<span class="icon icon-css icon-16" style="background: url(chrome://${config.addonRef}/content/icons/favicon.png) content-box no-repeat center/contain;" />`
+			iconPath: getPref(ANNOTATIONS_COUNT_COLUMN_FORMAT_SHOW_ICON_PREF)
+				? `chrome://${config.addonRef}/content/icons/favicon.png`
 				: undefined,
 			label: getString("annotations-column-name"),
-			pluginID: "",
+			pluginID: config.addonID,
+			minWidth: 26,
+			staticWidth: true,
 			dataProvider: (item: Zotero.Item, dataKey: string) => {
 				return this.getItemAnnotationsCount(item).toString();
 			},
@@ -60,6 +61,7 @@ export default class ZoteroAnnotationsCount {
 					`cell ${column.className}`,
 					"",
 				);
+				cell.style.textAlign = "center";
 				const text = this.createSpanElement(
 					"cell-text",
 					this.formatAnnotationsCount(data),

--- a/src/modules/overlay.ts
+++ b/src/modules/overlay.ts
@@ -61,7 +61,8 @@ export default class ZoteroAnnotationsCount {
 					`cell ${column.className}`,
 					"",
 				);
-				cell.style.textAlign = "center";
+				cell.style.display = "flex";
+				cell.style.justifyContent = "center";
 				const text = this.createSpanElement(
 					"cell-text",
 					this.formatAnnotationsCount(data),


### PR DESCRIPTION
<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td><img  height="200" alt="85e772bc-aa8a-44db-a90a-46de7098f39e" src="https://github.com/user-attachments/assets/ef8715d6-4c7f-4ed7-ae54-0ecaf5889bf7" /></td>
    <td><img height="200" alt="69ec7cca-d753-4b9d-91b3-6c06f14a4e51" src="https://github.com/user-attachments/assets/c22308b6-22b8-4f22-a5ab-941f95cb10d0" /></td>
  </tr>
  <tr>
    <td>Before (at the minWidth)</td>
    <td>After (at the minWidth, same as numNotes)</td>
  </tr>
  <tr>
    <td><img height="200" alt="image" src="https://github.com/user-attachments/assets/7357f9b2-4014-4057-a810-3da7ce81b78a" /></td>
    <td><img height="200" alt="image" src="https://github.com/user-attachments/assets/2a354144-d1f9-46da-b201-64ff04882b0e" /></td>
  </tr>
</table>
